### PR TITLE
Add Echo utilities for TMU and glyph management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.egg-info/
+memory/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-# echo
-AI proxy
+# Echo
+
+Echo is an offline proxy designed to manage symbolic memory units and glyphs for the Aurora project.
+
+The `echo` Python package provides utilities for:
+
+- Handling **Token Memory Units** (TMUs) stored as JSON files.
+- Encoding and decoding glyphs used to preserve identity and meaning.
+- Detecting glyph-like patterns within text.
+- Creating and storing memory fragments to disk.
+
+## Installation
+
+This repository uses a simple `src` layout. You can install the package in editable mode using:
+
+```bash
+pip install -e .
+```
+
+## Example
+
+```python
+from echo import (
+    create_memory_fragment,
+    store_memory_fragment,
+    encode_text_as_glyph,
+    decode_text_from_glyph,
+    detect_glyphs_in_text,
+)
+
+# create a memory fragment and store it
+tmu = create_memory_fragment("Hello world")
+store_memory_fragment(tmu, "memory")
+
+# encode and decode a glyph
+glyph = encode_text_as_glyph("sample")
+text = decode_text_from_glyph(glyph)
+print(glyph, text)
+
+# detect glyph-like tokens
+print(detect_glyphs_in_text("Alpha-0x7F meets Zeta-V0ID"))
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "echo"
+version = "0.1.0"
+description = "Echo AI proxy tools"
+readme = "README.md"
+requires-python = ">=3.11"
+
+[project.optional-dependencies]
+test = ["pytest"]

--- a/src/echo/__init__.py
+++ b/src/echo/__init__.py
@@ -1,0 +1,28 @@
+"""Echo AI proxy package."""
+
+from .tmu import TMU, load_tmu, save_tmu
+from .glyph import encode_glyph, decode_glyph
+from .patterns import find_glyphs
+from .interface import (
+    create_memory_fragment,
+    store_memory_fragment,
+    load_memory_fragment,
+    encode_text_as_glyph,
+    decode_text_from_glyph,
+    detect_glyphs_in_text,
+)
+
+__all__ = [
+    "TMU",
+    "load_tmu",
+    "save_tmu",
+    "encode_glyph",
+    "decode_glyph",
+    "find_glyphs",
+    "create_memory_fragment",
+    "store_memory_fragment",
+    "load_memory_fragment",
+    "encode_text_as_glyph",
+    "decode_text_from_glyph",
+    "detect_glyphs_in_text",
+]

--- a/src/echo/glyph.py
+++ b/src/echo/glyph.py
@@ -1,0 +1,17 @@
+import base64
+
+GLYPH_PREFIX = "glyph:"
+
+
+def encode_glyph(text: str) -> str:
+    """Encode text into a glyph string."""
+    encoded = base64.urlsafe_b64encode(text.encode("utf-8")).decode("ascii")
+    return f"{GLYPH_PREFIX}{encoded}"
+
+
+def decode_glyph(glyph: str) -> str:
+    """Decode a glyph string back into text."""
+    if not glyph.startswith(GLYPH_PREFIX):
+        raise ValueError("Invalid glyph")
+    data = glyph[len(GLYPH_PREFIX):]
+    return base64.urlsafe_b64decode(data.encode("ascii")).decode("utf-8")

--- a/src/echo/interface.py
+++ b/src/echo/interface.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any, Dict
+
+from .tmu import TMU, save_tmu, load_tmu
+from .glyph import encode_glyph, decode_glyph
+from .patterns import find_glyphs
+
+
+def create_memory_fragment(text: str, metadata: Dict[str, Any] | None = None) -> TMU:
+    """Create a TMU from raw text."""
+    fragment_id = str(uuid.uuid4())
+    return TMU(id=fragment_id, content=text, metadata=metadata)
+
+
+def store_memory_fragment(tmu: TMU, directory: str | Path) -> Path:
+    """Store TMU as a JSON file within a directory."""
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{tmu.id}.json"
+    save_tmu(tmu, path)
+    return path
+
+
+def load_memory_fragment(fragment_id: str, directory: str | Path) -> TMU:
+    """Load TMU from a directory by id."""
+    path = Path(directory) / f"{fragment_id}.json"
+    return load_tmu(path)
+
+
+def encode_text_as_glyph(text: str) -> str:
+    """Encode text as a glyph."""
+    return encode_glyph(text)
+
+
+def decode_text_from_glyph(glyph: str) -> str:
+    """Decode text from a glyph."""
+    return decode_glyph(glyph)
+
+
+def detect_glyphs_in_text(text: str) -> list[str]:
+    """Return all glyph-like patterns in text."""
+    return list(find_glyphs(text))

--- a/src/echo/patterns.py
+++ b/src/echo/patterns.py
@@ -1,0 +1,9 @@
+import re
+from typing import Iterable
+
+GLYPH_PATTERN = re.compile(r"[A-Za-z]+-[A-Za-z0-9]+")
+
+
+def find_glyphs(text: str) -> Iterable[str]:
+    """Yield glyph-like patterns from text."""
+    return GLYPH_PATTERN.findall(text)

--- a/src/echo/tmu.py
+++ b/src/echo/tmu.py
@@ -1,0 +1,35 @@
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Dict
+
+@dataclass
+class TMU:
+    """Token Memory Unit."""
+    id: str
+    content: str
+    metadata: Dict[str, Any] | None = None
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), ensure_ascii=False, indent=2)
+
+    @staticmethod
+    def from_json(data: str) -> 'TMU':
+        payload = json.loads(data)
+        return TMU(
+            id=payload.get("id", ""),
+            content=payload.get("content", ""),
+            metadata=payload.get("metadata"),
+        )
+
+
+def load_tmu(path: str | Path) -> TMU:
+    """Load a TMU from a JSON file."""
+    with open(path, "r", encoding="utf-8") as fh:
+        return TMU.from_json(fh.read())
+
+
+def save_tmu(tmu: TMU, path: str | Path) -> None:
+    """Save a TMU to a JSON file."""
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(tmu.to_json())

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,25 @@
+from echo import (
+    create_memory_fragment,
+    encode_text_as_glyph,
+    decode_text_from_glyph,
+    detect_glyphs_in_text,
+)
+
+
+def test_memory_fragment_roundtrip(tmp_path):
+    tmu = create_memory_fragment("hi")
+    path = tmp_path / "tmu.json"
+    from echo import store_memory_fragment, load_memory_fragment
+    store_memory_fragment(tmu, tmp_path)
+    loaded = load_memory_fragment(tmu.id, tmp_path)
+    assert loaded.content == "hi"
+
+
+def test_glyph_encoding():
+    glyph = encode_text_as_glyph("data")
+    assert decode_text_from_glyph(glyph) == "data"
+
+
+def test_detect_glyphs():
+    text = "Alpha-0x7F meets Beta-1"
+    assert detect_glyphs_in_text(text) == ["Alpha-0x7F", "Beta-1"]


### PR DESCRIPTION
## Summary
- add package skeleton under `src/echo`
- implement memory unit helpers and glyph encoding
- implement interface for storing/loading memory fragments
- add basic regex-based glyph detection
- document usage in README
- configure `pyproject.toml`
- add tests verifying glyphs and TMUs

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c7e237dd88325b02c35ead1ea0881