### PR TITLE
Add cross-platform shell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ complex workflows can be triggered via N8N.
   upload custom scripts for execution.
 - **Automatic command presets** – at first launch, AuroraShell detects your
   operating system and seeds the allowlist with common utilities.
+- **Cross-platform shell support** – the executor uses `/bin/bash` on POSIX
+  systems and falls back to the default Windows shell when running on
+  Windows.
 
 To start the server:
 

--- a/executor.py
+++ b/executor.py
@@ -1,6 +1,7 @@
 import subprocess
 import logging
 from typing import Tuple
+import platform
 
 logger = logging.getLogger(__name__)
 
@@ -8,14 +9,16 @@ logger = logging.getLogger(__name__)
 def run_command(command: str, timeout: int = 30) -> Tuple[int, str, str]:
     """Execute command in subprocess and return (returncode, stdout, stderr)."""
     try:
-        result = subprocess.run(
-            command,
-            shell=True,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            executable="/bin/bash",
-        )
+        kwargs = {
+            "shell": True,
+            "capture_output": True,
+            "text": True,
+            "timeout": timeout,
+        }
+        # Use bash on POSIX systems and default shell on Windows
+        if not platform.system().lower().startswith("win"):
+            kwargs["executable"] = "/bin/bash"
+        result = subprocess.run(command, **kwargs)
         logger.info("Executed command: %s", command)
         return result.returncode, result.stdout, result.stderr
     except Exception as exc:


### PR DESCRIPTION
## Summary
- let `executor.run_command` choose bash or cmd
- mention shell choice in README

## Testing
- `python -m py_compile executor.py`


------
https://chatgpt.com/codex/tasks/task_e_6883c875ae888325a5210a3302becfeb