### PR TITLE
Enhance UI navigation and status indicators

### DIFF
--- a/static/status.js
+++ b/static/status.js
@@ -1,0 +1,28 @@
+async function updateStatusLights(){
+  try{
+    const res = await fetch('/status');
+    const data = await res.json();
+    const container = document.getElementById('status-lights');
+    if(!container) return;
+    container.innerHTML = '';
+    for(const [name, ok] of Object.entries(data)){
+      const a = document.createElement('a');
+      a.href = '/?settings=' + name;
+      a.onclick = function(e){
+        if(typeof openSettings === 'function'){
+          e.preventDefault();
+          openSettings(name);
+        }
+      };
+      const dot = document.createElement('div');
+      dot.className = 'status-dot' + (ok ? ' green' : '');
+      a.appendChild(dot);
+      container.appendChild(a);
+    }
+  }catch(e){
+    console.error(e);
+  }
+}
+updateStatusLights();
+setInterval(updateStatusLights, 10000);
+

--- a/static/style.css
+++ b/static/style.css
@@ -15,6 +15,7 @@ body {
     border-radius: 8px;
     width: 80%;
     max-width: 600px;
+    margin-top: 60px;
 }
 
 .chat-log {
@@ -109,4 +110,61 @@ body {
     color: #fff;
     border-radius: 4px;
     cursor: pointer;
+}
+
+/* navigation bar */
+.navbar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    background: rgba(0, 0, 0, 0.7);
+    padding: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    z-index: 1000;
+}
+
+.nav-links a {
+    margin-right: 10px;
+    color: #fff;
+    text-decoration: none;
+}
+
+/* status indicator */
+.status-lights {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.status-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: red;
+}
+
+.status-dot.green {
+    background: #66bb6a;
+}
+
+@keyframes fadeInUp {
+    from {opacity: 0; transform: translateY(10px);}
+    to {opacity: 1; transform: translateY(0);}
+}
+
+.user-msg, .bot-msg {
+    animation: fadeInUp 0.3s ease;
+}
+
+.settings-panel {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+}
+
+.settings-panel.active {
+    max-height: 500px;
 }

--- a/templates/commands.html
+++ b/templates/commands.html
@@ -6,15 +6,24 @@
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <div class="chat-container">
-        <h1>Allowed Commands</h1>
-        <a href="/" style="color:#fff">Back</a>
-        <div id="cmd-list" class="chat-log" style="height:200px"></div>
-        <div class="input-area">
-            <input id="new-cmd" type="text" placeholder="Add command or script" />
-            <button onclick="addCmd()">Add</button>
-        </div>
+<header class="navbar">
+    <div class="nav-links">
+        <a href="/">Chat</a>
+        <a href="/lmchat">LM Chat</a>
+        <a href="/commands">Commands</a>
+        <a href="/system">System Status</a>
+        <a href="/?settings=1" class="settings-link">Settings</a>
     </div>
+    <div id="status-lights" class="status-lights"></div>
+</header>
+<div class="chat-container">
+    <h1>Allowed Commands</h1>
+    <div id="cmd-list" class="chat-log" style="height:200px"></div>
+    <div class="input-area">
+        <input id="new-cmd" type="text" placeholder="Add command or script" />
+        <button onclick="addCmd()">Add</button>
+    </div>
+</div>
 <script>
 async function loadList(){
     const res = await fetch('/allowlist');
@@ -41,5 +50,6 @@ async function addCmd(){
 }
 loadList();
 </script>
+<script src="/static/status.js"></script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,32 +7,37 @@
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <div class="chat-container">
-        <h1>AuroraShell</h1>
-        <a href="/system" style="color:#fff">System Status</a>
-        <a href="/lmchat" style="color:#fff; margin-left:10px">LM Studio Chat</a>
-        <a href="/commands" style="color:#fff; margin-left:10px">Commands</a>
+<header class="navbar">
+    <div class="nav-links">
+        <a href="/">Chat</a>
+        <a href="/lmchat">LM Chat</a>
+        <a href="/commands">Commands</a>
+        <a href="/system">System Status</a>
         <span class="settings-link" onclick="toggleSettings()">Settings</span>
-        <div id="settings" class="settings-panel">
-            <label>LM Studio URL:<br><input id="lmstudio_url" /></label>
-            <label>LM Studio Token:<br><input id="lmstudio_token" /></label>
-            <label>AnythingLLM URL:<br><input id="anythingllm_url" /></label>
-            <label>AnythingLLM Token:<br><input id="anythingllm_token" /></label>
-            <label>N8N URL:<br><input id="n8n_url" /></label>
-            <label>N8N Token:<br><input id="n8n_token" /></label>
-            <button onclick="saveSettings()">Save</button>
-        </div>
-        <div id="toast" class="toast" style="display:none"></div>
-        <div id="chat-log" class="chat-log"></div>
-        <div class="input-area">
-            <select id="mode">
-                <option value="chat">Chat</option>
-                <option value="execute">Execute</option>
-            </select>
-            <input type="text" id="chat-input" placeholder="Type your message..." />
-            <input type="text" id="chat-input" placeholder="Type your command..." />
-            <button onclick="sendMessage()">Send</button>
-        </div>
+    </div>
+    <div id="status-lights" class="status-lights"></div>
+</header>
+<div class="chat-container">
+    <h1>AuroraShell</h1>
+    <div id="settings" class="settings-panel">
+        <label>LM Studio URL:<br><input id="lmstudio_url" /></label>
+        <label>LM Studio Token:<br><input id="lmstudio_token" /></label>
+        <label>AnythingLLM URL:<br><input id="anythingllm_url" /></label>
+        <label>AnythingLLM Token:<br><input id="anythingllm_token" /></label>
+        <label>N8N URL:<br><input id="n8n_url" /></label>
+        <label>N8N Token:<br><input id="n8n_token" /></label>
+        <button onclick="saveSettings()">Save</button>
+    </div>
+    <div id="toast" class="toast" style="display:none"></div>
+    <div id="chat-log" class="chat-log"></div>
+    <div class="input-area">
+        <select id="mode">
+            <option value="chat">Chat</option>
+            <option value="execute">Execute</option>
+        </select>
+        <input type="text" id="chat-input" placeholder="Type your message or command..." />
+        <button onclick="sendMessage()">Send</button>
+    </div>
 </div>
 <script>
 const toastEl = document.getElementById('toast');
@@ -48,11 +53,22 @@ async function loadSettings(){
 }
 
 function toggleSettings(){
-    if(settingsEl.style.display==='block'){
-        settingsEl.style.display='none';
+    if(settingsEl.classList.contains('active')){
+        settingsEl.classList.remove('active');
     } else {
-        settingsEl.style.display='block';
+        settingsEl.classList.add('active');
         loadSettings();
+    }
+}
+
+function openSettings(service){
+    if(!settingsEl.classList.contains('active')){
+        toggleSettings();
+    }
+    const map = {lmstudio:'lmstudio_url', anythingllm:'anythingllm_url', n8n:'n8n_url'};
+    const id = map[service];
+    if(id){
+        setTimeout(()=>{document.getElementById(id).focus();},100);
     }
 }
 
@@ -91,7 +107,6 @@ async function sendMessage() {
     const modeSel = document.getElementById('mode');
     const text = input.value;
     const mode = modeSel.value;
-    const text = input.value;
     if (!text) return;
     const log = document.getElementById('chat-log');
     log.innerHTML += `<div class='user-msg'>${text}</div>`;
@@ -105,10 +120,6 @@ async function sendMessage() {
     if (data.response) {
         log.innerHTML += `<div class='bot-msg'>${data.response}</div>`;
     } else if (data.plan) {
-        body: JSON.stringify({message: text})
-    });
-    const data = await res.json();
-    if (data.plan) {
         log.innerHTML += `<div class='bot-msg'>Plan: ${JSON.stringify(data.plan)}</div>`;
         const approve = confirm('Execute this plan?');
         if (approve) {
@@ -127,6 +138,15 @@ async function sendMessage() {
     }
     log.scrollTop = log.scrollHeight;
 }
+
+window.addEventListener('load', () => {
+    const params = new URLSearchParams(window.location.search);
+    const open = params.get('settings');
+    if(open){
+        openSettings(open);
+    }
+});
 </script>
+<script src="/static/status.js"></script>
 </body>
 </html>

--- a/templates/lmchat.html
+++ b/templates/lmchat.html
@@ -7,15 +7,24 @@
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <div class="chat-container">
-        <h1>LM Studio Chat</h1>
-        <a href="/" style="color:#fff">Back</a>
-        <div id="chat-log" class="chat-log"></div>
-        <div class="input-area">
-            <input type="text" id="chat-input" placeholder="Type your message..." />
-            <button onclick="sendMessage()">Send</button>
-        </div>
+<header class="navbar">
+    <div class="nav-links">
+        <a href="/">Chat</a>
+        <a href="/lmchat">LM Chat</a>
+        <a href="/commands">Commands</a>
+        <a href="/system">System Status</a>
+        <a href="/?settings=1" class="settings-link">Settings</a>
     </div>
+    <div id="status-lights" class="status-lights"></div>
+</header>
+<div class="chat-container">
+    <h1>LM Studio Chat</h1>
+    <div id="chat-log" class="chat-log"></div>
+    <div class="input-area">
+        <input type="text" id="chat-input" placeholder="Type your message..." />
+        <button onclick="sendMessage()">Send</button>
+    </div>
+</div>
 <script>
 async function sendMessage(){
     const input=document.getElementById('chat-input');
@@ -38,5 +47,6 @@ async function sendMessage(){
     log.scrollTop=log.scrollHeight;
 }
 </script>
+<script src="/static/status.js"></script>
 </body>
 </html>

--- a/templates/status.html
+++ b/templates/status.html
@@ -12,11 +12,20 @@
     </style>
 </head>
 <body>
-    <div class="chat-container">
-        <h1>System Status</h1>
-        <div id="status" class="status-grid"></div>
-        <a href="/">Back</a>
+<header class="navbar">
+    <div class="nav-links">
+        <a href="/">Chat</a>
+        <a href="/lmchat">LM Chat</a>
+        <a href="/commands">Commands</a>
+        <a href="/system">System Status</a>
+        <a href="/?settings=1" class="settings-link">Settings</a>
     </div>
+    <div id="status-lights" class="status-lights"></div>
+</header>
+<div class="chat-container">
+    <h1>System Status</h1>
+    <div id="status" class="status-grid"></div>
+</div>
 <script>
 async function refreshStatus(){
     const res=await fetch('/status');
@@ -38,5 +47,6 @@ async function refreshStatus(){
 refreshStatus();
 setInterval(refreshStatus, 10000);
 </script>
+<script src="/static/status.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add persistent status indicators
- animate messages and improve settings panel
- introduce navigation bar on all pages
- update commands, LM chat and status pages

## Testing
- `python -m py_compile chat_interface.py executor.py llm_interpreter.py planner.py rag_client.py task_logger.py validator.py n8n_client.py cupcake_game.py`
- `pip install flask requests pyyaml`
- `python chat_interface.py` *(fails without Flask, installed and ran successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6884f6dce5908325978856d39581172c