### PR TITLE
Add shared workflow diagram

### DIFF
--- a/templates/_workflow.html
+++ b/templates/_workflow.html
@@ -1,0 +1,27 @@
+<svg viewBox="0 0 720 80" xmlns="http://www.w3.org/2000/svg" class="workflow-diagram">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#333" />
+    </marker>
+  </defs>
+  <g fill="#eee" stroke="#333">
+    <rect x="10"  y="20" width="100" height="40" />
+    <rect x="150" y="20" width="100" height="40" />
+    <rect x="290" y="20" width="100" height="40" />
+    <rect x="430" y="20" width="100" height="40" />
+    <rect x="570" y="20" width="100" height="40" />
+  </g>
+  <g font-size="12" text-anchor="middle" dominant-baseline="middle">
+    <text x="60"  y="40">UI</text>
+    <text x="200" y="40">Planner</text>
+    <text x="340" y="40">Validator</text>
+    <text x="480" y="40">Executor</text>
+    <text x="620" y="40">Shell</text>
+  </g>
+  <g stroke="#333" stroke-width="2" fill="none" marker-end="url(#arrow)">
+    <line x1="110" y1="40" x2="150" y2="40" />
+    <line x1="250" y1="40" x2="290" y2="40" />
+    <line x1="390" y1="40" x2="430" y2="40" />
+    <line x1="530" y1="40" x2="570" y2="40" />
+  </g>
+</svg>

--- a/templates/commands.html
+++ b/templates/commands.html
@@ -18,6 +18,7 @@
 </header>
 <div class="chat-container">
     <h1>Allowed Commands</h1>
+    {% include "_workflow.html" %}
     <div id="cmd-list" class="chat-log" style="height:200px"></div>
     <div class="input-area">
         <input id="new-cmd" type="text" placeholder="Add command or script" />

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,6 +19,7 @@
 </header>
 <div class="chat-container">
     <h1>AuroraShell</h1>
+    {% include "_workflow.html" %}
     <div id="settings" class="settings-panel">
         <div class="svc">
             <label>LM Studio:<br>

--- a/templates/lmchat.html
+++ b/templates/lmchat.html
@@ -19,6 +19,7 @@
 </header>
 <div class="chat-container">
     <h1>LM Studio Chat</h1>
+    {% include "_workflow.html" %}
     <div id="chat-log" class="chat-log"></div>
     <div class="input-area">
         <input type="text" id="chat-input" placeholder="Type your message..." />

--- a/templates/status.html
+++ b/templates/status.html
@@ -24,6 +24,7 @@
 </header>
 <div class="chat-container">
     <h1>System Status</h1>
+    {% include "_workflow.html" %}
     <div id="status" class="status-grid"></div>
 </div>
 <script>


### PR DESCRIPTION
## Summary
- add a new `_workflow.html` containing the planner/validator/executor diagram
- include this fragment in the four HTML templates so the diagram is maintained in one place

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68850747895c832593167eb73918cbcc