### PR TITLE
Remove settings menu and embed inline config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ complex workflows can be triggered via N8N.
   between normal conversation or command execution using the mode selector.
 - **LM Studio chat page** – a focused interface at `/lmchat` for direct
   conversations with the model.
-- **Settings panel** – configure server URLs and API tokens on the fly without
-  restarting the daemon.
+- **Inline configuration** – update server URLs and API tokens from the form
+  under the status indicators without restarting the daemon.
 - **System status dashboard** – `/system` displays green/red indicators for
   LM Studio, AnythingLLM and N8N with automatic reconnection checks every
   10&nbsp;seconds. Connection events appear as toast notifications.
@@ -84,14 +84,13 @@ with `{"approve": true}` to execute the plan.
 
 4. **Configure AuroraShell**
 
-   Edit `config.yaml` and replace the default server addresses, ports, and
-   any API tokens required by your local services. You can also open the
-   **Settings** menu in the web UI to change these values while AuroraShell
-   is running. Example configuration values:
+    Edit `config.yaml` and replace the default server addresses, ports, and
+    any API tokens required by your local services. You can also adjust these
+    values from the inline configuration form in the web UI while AuroraShell
+    is running. Example configuration values:
 
-   You can edit `config.yaml` directly or open the **Settings** menu in the
-   web UI to update server addresses and API tokens at runtime. Example
-   configuration values:
+    You can edit `config.yaml` directly or use the inline form to update server
+    addresses and API tokens at runtime. Example configuration values:
 
    ```yaml
   port: 5000
@@ -110,8 +109,8 @@ with `{"approve": true}` to execute the plan.
      server used for memory/context retrieval
    - `lmstudio_url` and `lmstudio_token` – LM Studio API endpoint and token
 
-   If your services require authentication tokens, fill in the appropriate
-   fields in `config.yaml` or via the Settings menu.
+    If your services require authentication tokens, fill in the appropriate
+    fields in `config.yaml` or using the inline form.
 
    The same file also contains an `allowlist` array defining which commands
    may be executed. If the list is empty on first run, AuroraShell detects your
@@ -125,8 +124,8 @@ with `{"approve": true}` to execute the plan.
   lmstudio_token: ""
   ```
 
-   If your services require authentication tokens, fill in the appropriate
-   fields in `config.yaml` or via the Settings menu.
+    If your services require authentication tokens, fill in the appropriate
+    fields in `config.yaml` or using the inline form.
 
 
 5. **Run the server**
@@ -140,8 +139,8 @@ with `{"approve": true}` to execute the plan.
    Open `http://<your-ip>:<port>/` in your browser (replace the default
    values with those you configured) to begin chatting with the agent.
 
-   Visit `/system` to view the status dashboard. Use the **Settings** link
-   in the top bar to adjust endpoints while the server is running.
+    Visit `/system` to view the status dashboard. Use the inline form at the
+    top right to adjust endpoints while the server is running.
    Services that are unavailable will show a red light and the server will
    automatically retry the connection every 10 seconds.
 

--- a/static/status.js
+++ b/static/status.js
@@ -3,21 +3,19 @@ async function updateStatusLights(){
     const res = await fetch('/status');
     const data = await res.json();
     const container = document.getElementById('status-lights');
-    if(!container) return;
-    container.innerHTML = '';
+    if(container){
+      container.innerHTML = '';
+      for(const [name, ok] of Object.entries(data)){
+        const dot = document.createElement('div');
+        dot.className = 'status-dot' + (ok ? ' green' : '');
+        container.appendChild(dot);
+      }
+    }
     for(const [name, ok] of Object.entries(data)){
-      const a = document.createElement('a');
-      a.href = '/?settings=' + name;
-      a.onclick = function(e){
-        if(typeof openSettings === 'function'){
-          e.preventDefault();
-          openSettings(name);
-        }
-      };
-      const dot = document.createElement('div');
-      dot.className = 'status-dot' + (ok ? ' green' : '');
-      a.appendChild(dot);
-      container.appendChild(a);
+      const fieldDot = document.getElementById('form-status-' + name);
+      if(fieldDot){
+        fieldDot.className = 'status-dot' + (ok ? ' green' : '');
+      }
     }
   }catch(e){
     console.error(e);

--- a/static/style.css
+++ b/static/style.css
@@ -80,36 +80,6 @@ body {
     z-index: 1000;
 }
 
-.settings-link {
-    margin-left: 10px;
-    cursor: pointer;
-    color: #fff;
-}
-
-.settings-panel {
-    display: none;
-    background: #222;
-    padding: 10px;
-    border-radius: 4px;
-    margin-top: 10px;
-}
-
-.settings-panel input {
-    width: 100%;
-    margin-bottom: 5px;
-    padding: 6px;
-    border-radius: 4px;
-    border: none;
-}
-
-.settings-panel button {
-    padding: 8px 12px;
-    border: none;
-    background: #2196f3;
-    color: #fff;
-    border-radius: 4px;
-    cursor: pointer;
-}
 
 /* navigation bar */
 .navbar {
@@ -149,6 +119,42 @@ body {
     background: #66bb6a;
 }
 
+.config-form {
+    position: fixed;
+    top: 50px;
+    right: 10px;
+    background: #222;
+    padding: 10px;
+    border-radius: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    z-index: 900;
+}
+
+.config-item {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.config-item input {
+    padding: 4px 6px;
+    border-radius: 4px;
+    border: none;
+    background: #333;
+    color: #fff;
+}
+
+.config-form button {
+    padding: 6px 12px;
+    border: none;
+    background: #2196f3;
+    color: #fff;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
 @keyframes fadeInUp {
     from {opacity: 0; transform: translateY(10px);}
     to {opacity: 1; transform: translateY(0);}
@@ -158,12 +164,3 @@ body {
     animation: fadeInUp 0.3s ease;
 }
 
-.settings-panel {
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height 0.3s ease;
-}
-
-.settings-panel.active {
-    max-height: 500px;
-}

--- a/templates/commands.html
+++ b/templates/commands.html
@@ -12,7 +12,6 @@
         <a href="/lmchat">LM Chat</a>
         <a href="/commands">Commands</a>
         <a href="/system">System Status</a>
-        <a href="/?settings=1" class="settings-link">Settings</a>
     </div>
     <div id="status-lights" class="status-lights"></div>
 </header>

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,32 +13,26 @@
         <a href="/lmchat">LM Chat</a>
         <a href="/commands">Commands</a>
         <a href="/system">System Status</a>
-        <span class="settings-link" onclick="toggleSettings()">Settings</span>
     </div>
     <div id="status-lights" class="status-lights"></div>
 </header>
 <div class="chat-container">
     <h1>AuroraShell</h1>
     {% include "_workflow.html" %}
-    <div id="settings" class="settings-panel">
-        <div class="svc">
-            <label>LM Studio:<br>
-                <select id="lmstudio_select" onchange="selectChanged('lmstudio')"></select>
-                <button onclick="deleteServer('lmstudio')">Delete</button>
-            </label>
+    <div id="config" class="config-form">
+        <div class="config-item"><div id="form-status-lmstudio" class="status-dot"></div>
+            <input id="lmstudio_url" placeholder="LM Studio URL">
+            <input id="lmstudio_token" placeholder="Token">
         </div>
-        <div class="svc">
-            <label>AnythingLLM:<br>
-                <select id="anythingllm_select" onchange="selectChanged('anythingllm')"></select>
-                <button onclick="deleteServer('anythingllm')">Delete</button>
-            </label>
+        <div class="config-item"><div id="form-status-anythingllm" class="status-dot"></div>
+            <input id="anythingllm_url" placeholder="AnythingLLM URL">
+            <input id="anythingllm_token" placeholder="Token">
         </div>
-        <div class="svc">
-            <label>N8N:<br>
-                <select id="n8n_select" onchange="selectChanged('n8n')"></select>
-                <button onclick="deleteServer('n8n')">Delete</button>
-            </label>
+        <div class="config-item"><div id="form-status-n8n" class="status-dot"></div>
+            <input id="n8n_url" placeholder="N8N URL">
+            <input id="n8n_token" placeholder="Token">
         </div>
+        <button onclick="saveSettings()">Save</button>
     </div>
     <div id="toast" class="toast" style="display:none"></div>
     <div id="chat-log" class="chat-log"></div>
@@ -53,53 +47,22 @@
 </div>
 <script>
 const toastEl = document.getElementById('toast');
-const settingsEl = document.getElementById('settings');
 let settingsData = {};
 
 async function loadSettings(){
     const res = await fetch('/settings');
     settingsData = await res.json();
-    ['lmstudio','anythingllm','n8n'].forEach(svc=>{
-        const sel = document.getElementById(svc + '_select');
-        if(!sel) return;
-        sel.innerHTML = '';
-        const servers = settingsData[svc + '_servers'] || [];
-        const currentUrl = settingsData[svc + '_url'] || '';
-        servers.forEach((srv,i)=>{
-            const opt = document.createElement('option');
-            opt.value = i;
-            opt.textContent = srv.url;
-            if(srv.url === currentUrl) opt.selected = true;
-            sel.appendChild(opt);
-        });
-        const addOpt = document.createElement('option');
-        addOpt.value = 'new';
-        addOpt.textContent = 'Add new...';
-        sel.appendChild(addOpt);
+    ['lmstudio','anythingllm','n8n'].forEach(svc => {
+        document.getElementById(svc + '_url').value = settingsData[svc + '_url'] || '';
+        document.getElementById(svc + '_token').value = settingsData[svc + '_token'] || '';
     });
 }
 
-function toggleSettings(){
-    if(settingsEl.classList.contains('active')){
-        settingsEl.classList.remove('active');
-    } else {
-        settingsEl.classList.add('active');
-        loadSettings();
-    }
-}
-
-function openSettings(service){
-    if(!settingsEl.classList.contains('active')){
-        toggleSettings();
-    }
-    const map = {lmstudio:'lmstudio_select', anythingllm:'anythingllm_select', n8n:'n8n_select'};
-    const id = map[service];
-    if(id){
-        setTimeout(()=>{document.getElementById(id).focus();},100);
-    }
-}
-
 async function saveSettings(){
+    ['lmstudio','anythingllm','n8n'].forEach(svc => {
+        settingsData[svc + '_url'] = document.getElementById(svc + '_url').value.trim();
+        settingsData[svc + '_token'] = document.getElementById(svc + '_token').value.trim();
+    });
     await fetch('/settings', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
@@ -112,49 +75,6 @@ function showToast(msg){
     toastEl.textContent = msg;
     toastEl.style.display='block';
     setTimeout(()=>{toastEl.style.display='none';},3000);
-}
-
-function selectChanged(service){
-    const sel = document.getElementById(service + '_select');
-    if(!sel) return;
-    if(sel.value === 'new'){
-        const url = prompt('Server URL:');
-        if(!url){ loadSettings(); return; }
-        const token = prompt('Token (optional):') || '';
-        settingsData[service + '_servers'] = settingsData[service + '_servers'] || [];
-        settingsData[service + '_servers'].push({url, token});
-        settingsData[service + '_url'] = url;
-        settingsData[service + '_token'] = token;
-        saveSettings().then(loadSettings);
-    } else {
-        const idx = parseInt(sel.value,10);
-        const srv = (settingsData[service + '_servers'] || [])[idx];
-        if(srv){
-            settingsData[service + '_url'] = srv.url;
-            settingsData[service + '_token'] = srv.token;
-            saveSettings();
-        }
-    }
-}
-
-function deleteServer(service){
-    const sel = document.getElementById(service + '_select');
-    const idx = parseInt(sel.value,10);
-    if(isNaN(idx)) return;
-    if(!confirm('Delete this server?')) return;
-    const list = settingsData[service + '_servers'] || [];
-    const removed = list.splice(idx,1);
-    if(settingsData[service + '_url'] === removed[0].url){
-        if(list.length){
-            settingsData[service + '_url'] = list[0].url;
-            settingsData[service + '_token'] = list[0].token;
-        }else{
-            settingsData[service + '_url'] = '';
-            settingsData[service + '_token'] = '';
-        }
-    }
-    settingsData[service + '_servers'] = list;
-    saveSettings().then(loadSettings);
 }
 
 async function pollEvents(){
@@ -202,11 +122,7 @@ async function sendMessage() {
 }
 
 window.addEventListener('load', () => {
-    const params = new URLSearchParams(window.location.search);
-    const open = params.get('settings');
-    if(open){
-        openSettings(open);
-    }
+    loadSettings();
 });
 </script>
 <script src="/static/status.js"></script>

--- a/templates/lmchat.html
+++ b/templates/lmchat.html
@@ -13,7 +13,6 @@
         <a href="/lmchat">LM Chat</a>
         <a href="/commands">Commands</a>
         <a href="/system">System Status</a>
-        <a href="/?settings=1" class="settings-link">Settings</a>
     </div>
     <div id="status-lights" class="status-lights"></div>
 </header>

--- a/templates/status.html
+++ b/templates/status.html
@@ -18,7 +18,6 @@
         <a href="/lmchat">LM Chat</a>
         <a href="/commands">Commands</a>
         <a href="/system">System Status</a>
-        <a href="/?settings=1" class="settings-link">Settings</a>
     </div>
     <div id="status-lights" class="status-lights"></div>
 </header>


### PR DESCRIPTION
## Summary
- remove Settings links from navigation
- embed server configuration fields inline on the chat page
- update JS to load and save config via new form
- adjust status light updater for new layout
- clean up CSS and add styles for the inline config
- update documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68850cafcca883259bc71b8a5a8a09d8