### PR TITLE
Add workflow animation and command toast

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -260,3 +260,17 @@ body {
     to { stroke-dashoffset: -16; }
 }
 
+.workflow-diagram .pending {
+    fill: #2196f3;
+    stroke: #2196f3;
+}
+
+.workflow-diagram .active {
+    fill: #ffeb3b;
+    stroke: #ffeb3b;
+}
+
+.workflow-diagram .complete {
+    fill: #66bb6a;
+    stroke: #66bb6a;
+}

--- a/static/workflow.js
+++ b/static/workflow.js
@@ -1,0 +1,16 @@
+function setStepStatus(name, status){
+  const box = document.getElementById('box-'+name);
+  if(box){
+    box.classList.remove('pending','active','complete');
+    if(status) box.classList.add(status);
+  }
+  const arrow = document.getElementById('arrow-'+name);
+  if(arrow){
+    arrow.classList.remove('pending','active','complete');
+    if(status) arrow.classList.add(status);
+  }
+}
+
+function resetWorkflow(){
+  ['ui','planner','validator','executor','shell'].forEach(n => setStepStatus(n,''));
+}

--- a/templates/_workflow.html
+++ b/templates/_workflow.html
@@ -5,11 +5,11 @@
     </marker>
   </defs>
   <g fill="#eee" stroke="#333">
-    <rect x="10"  y="20" width="100" height="40" />
-    <rect x="150" y="20" width="100" height="40" />
-    <rect x="290" y="20" width="100" height="40" />
-    <rect x="430" y="20" width="100" height="40" />
-    <rect x="570" y="20" width="100" height="40" />
+    <rect id="box-ui" x="10"  y="20" width="100" height="40" />
+    <rect id="box-planner" x="150" y="20" width="100" height="40" />
+    <rect id="box-validator" x="290" y="20" width="100" height="40" />
+    <rect id="box-executor" x="430" y="20" width="100" height="40" />
+    <rect id="box-shell" x="570" y="20" width="100" height="40" />
   </g>
   <g font-size="12" text-anchor="middle" dominant-baseline="middle">
     <text x="60"  y="40">UI</text>
@@ -19,9 +19,9 @@
     <text x="620" y="40">Shell</text>
   </g>
   <g stroke="#333" stroke-width="2" fill="none" marker-end="url(#arrow)">
-    <line x1="110" y1="40" x2="150" y2="40" />
-    <line x1="250" y1="40" x2="290" y2="40" />
-    <line x1="390" y1="40" x2="430" y2="40" />
-    <line x1="530" y1="40" x2="570" y2="40" />
+    <line id="arrow-ui" x1="110" y1="40" x2="150" y2="40" />
+    <line id="arrow-planner" x1="250" y1="40" x2="290" y2="40" />
+    <line id="arrow-validator" x1="390" y1="40" x2="430" y2="40" />
+    <line id="arrow-executor" x1="530" y1="40" x2="570" y2="40" />
   </g>
 </svg>

--- a/templates/commands.html
+++ b/templates/commands.html
@@ -51,6 +51,7 @@ async function addCmd(){
 }
 loadList();
 </script>
+<script src="/static/workflow.js"></script>
 <script src="/static/status.js"></script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -121,6 +121,8 @@ async function sendMessage(msg, forcedMode) {
     const log = document.getElementById('chat-log');
     const btn = document.getElementById('send-btn');
     const spin = document.getElementById('spinner');
+    resetWorkflow();
+    setStepStatus('ui','active');
     log.innerHTML += `<div class='chat-bubble user-msg'>${text}</div>`;
     if (msg === undefined) input.value = '';
     btn.classList.add('pulse');
@@ -133,30 +135,55 @@ async function sendMessage(msg, forcedMode) {
     const data = await res.json();
     spin.style.display = 'none';
     btn.classList.remove('pulse');
+    setStepStatus('ui','complete');
+    setStepStatus('arrow-ui','complete');
+    setStepStatus('planner','complete');
+    setStepStatus('arrow-planner','pending');
     if (data.response) {
         log.innerHTML += `<div class='chat-bubble bot-msg'>${data.response}</div>`;
     } else if (data.summary) {
         log.innerHTML += `<div class='chat-bubble bot-msg'>${data.summary}</div>`;
+        showToast('Command: '+data.summary);
         const approve = confirm('Execute this command?');
         if (approve) {
+            setStepStatus('arrow-planner','complete');
+            setStepStatus('validator','active');
             const res2 = await fetch('/chat', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify({approve: true})
             });
             const result = await res2.json();
+            setStepStatus('validator','complete');
+            setStepStatus('arrow-validator','complete');
+            setStepStatus('executor','complete');
+            setStepStatus('arrow-executor','complete');
+            setStepStatus('shell','complete');
             log.innerHTML += `<div class='chat-bubble bot-msg'>Result: ${JSON.stringify(result)}</div>`;
         }
     } else if (data.plan) {
         log.innerHTML += `<div class='chat-bubble bot-msg'>Plan: ${JSON.stringify(data.plan)}</div>`;
+        try{
+            const firstTask = (data.plan.tasks || []).find(t => t.command);
+            if(firstTask){
+                showToast('Command: '+firstTask.command);
+            }
+        }catch(e){}
         const approve = confirm('Execute this plan?');
         if (approve) {
+            setStepStatus('arrow-planner','complete');
+            setStepStatus('validator','active');
             const res2 = await fetch('/chat', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify({approve: true})
             });
             const result = await res2.json();
+            setStepStatus('validator','complete');
+            setStepStatus('arrow-validator','complete');
+            setStepStatus('executor','complete');
+            setStepStatus('arrow-executor','complete');
+            setStepStatus('shell','complete');
             log.innerHTML += `<div class='chat-bubble bot-msg'>Result: ${JSON.stringify(result)}</div>`;
         }
     } else if (data.success !== undefined) {
@@ -241,8 +268,10 @@ window.addEventListener('load', () => {
     startLogStream();
     loadAllowlist();
     loadHostCommands();
+    resetWorkflow();
 });
 </script>
+<script src="/static/workflow.js"></script>
 <script src="/static/status.js"></script>
 </body>
 </html>

--- a/templates/lmchat.html
+++ b/templates/lmchat.html
@@ -55,6 +55,7 @@ async function sendMessage(){
     log.scrollTop=log.scrollHeight;
 }
 </script>
+<script src="/static/workflow.js"></script>
 <script src="/static/status.js"></script>
 </body>
 </html>

--- a/templates/probe.html
+++ b/templates/probe.html
@@ -58,6 +58,7 @@ async function addAll(){
 }
 loadInfo();
 </script>
+<script src="/static/workflow.js"></script>
 <script src="/static/status.js"></script>
 </body>
 </html>

--- a/templates/status.html
+++ b/templates/status.html
@@ -48,6 +48,7 @@ async function refreshStatus(){
 refreshStatus();
 setInterval(refreshStatus, 10000);
 </script>
+<script src="/static/workflow.js"></script>
 <script src="/static/status.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- mark workflow elements with IDs and animate them
- color workflow states using new CSS classes
- add reusable workflow.js helper
- show command string in toast messages
- load workflow script across pages

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688535e0d32083259bded7ada1a7c3f4