### PR TITLE
Add Grafana install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,15 @@ with `{"approve": true}` to execute the plan.
    source venv/bin/activate
    ```
 
-3. **Install Python dependencies**
+3. **Run the dependency installer**
 
    ```bash
-   pip install -r requirements.txt
+   ./scripts/install_dependencies.sh
    ```
+
+   This script installs the Python packages from `requirements.txt` and sets
+   up Grafana using the official APT repository. Grafana will be available on
+   port `3000` once the service starts.
 
 4. **Configure AuroraShell**
 

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Install Python dependencies
+if [[ -f "../requirements.txt" ]]; then
+    pip install -r ../requirements.txt
+fi
+
+# Install Grafana (Debian/Ubuntu)
+# This script uses the official Grafana APT repository.
+# Modify as needed for other distributions.
+if [[ "$EUID" -ne 0 ]]; then
+  echo "Please run as root to install Grafana" >&2
+  exit 1
+fi
+
+apt-get update
+apt-get install -y apt-transport-https software-properties-common wget
+wget -q -O - https://packages.grafana.com/gpg.key | apt-key add -
+add-apt-repository "deb https://packages.grafana.com/oss/deb stable main"
+apt-get update
+apt-get install -y grafana
+
+# Enable and start Grafana service
+systemctl enable grafana-server
+systemctl start grafana-server
+
+echo "Grafana installation complete. Access it on port 3000."


### PR DESCRIPTION
## Summary
- add a dependency installer script that installs Python requirements and Grafana
- document the new script in the installation section of the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `sudo bash scripts/install_dependencies.sh` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6887b89465d88325be40bc760864f451