### PR TITLE
Add draggable, resizable dashboard panes

### DIFF
--- a/static/drag.js
+++ b/static/drag.js
@@ -1,0 +1,29 @@
+const dashboard = document.querySelector('.dashboard');
+if(dashboard){
+  let dragPane = null;
+  dashboard.querySelectorAll('.pane').forEach(pane => {
+    const header = pane.querySelector('h1,h2');
+    if(header){
+      header.draggable = true;
+      header.style.cursor = 'move';
+      header.addEventListener('dragstart', e => {
+        dragPane = pane;
+        e.dataTransfer.setData('text/plain','');
+      });
+    }
+    pane.addEventListener('dragover', e => e.preventDefault());
+    pane.addEventListener('drop', e => {
+      e.preventDefault();
+      if(!dragPane || dragPane === pane) return;
+      const panes = Array.from(dashboard.querySelectorAll('.pane'));
+      const srcIndex = panes.indexOf(dragPane);
+      const tgtIndex = panes.indexOf(pane);
+      if(srcIndex < tgtIndex){
+        dashboard.insertBefore(dragPane, pane.nextSibling);
+      }else{
+        dashboard.insertBefore(dragPane, pane);
+      }
+      dragPane = null;
+    });
+  });
+}

--- a/static/style.css
+++ b/static/style.css
@@ -22,22 +22,15 @@ body {
     backdrop-filter: blur(4px);
 }
 
-/* grid layout for main dashboard */
+/* flexible layout for main dashboard */
 .dashboard {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-auto-rows: 1fr;
+    display: flex;
+    flex-wrap: wrap;
     gap: 10px;
     width: 90%;
     height: calc(100vh - 80px);
     margin-top: 60px;
-}
-
-@media (max-width: 700px) {
-    .dashboard {
-        grid-template-columns: 1fr;
-        grid-auto-rows: auto;
-    }
+    align-content: flex-start;
 }
 
 .pane {
@@ -46,9 +39,13 @@ body {
     border-radius: 8px;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    overflow: auto;
+    resize: both;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
     backdrop-filter: blur(4px);
+    min-width: 250px;
+    min-height: 180px;
+    flex: 1 1 45%;
 }
 
 .terminal-log {

--- a/templates/index.html
+++ b/templates/index.html
@@ -359,5 +359,6 @@ window.addEventListener('load', () => {
 </script>
 <script src="/static/workflow.js"></script>
 <script src="/static/status.js"></script>
+<script src="/static/drag.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- convert dashboard layout to a flexible flexbox
- allow panes to be resized using CSS
- new drag.js script enables rearranging panes
- load new script in index.html

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6887da7b3b4083258c417cfd73445c3f