### PR TITLE
Enhance PyQt GUI with raw LLM output and script history

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ complex workflows can be triggered via N8N.
 - **Cross-platform shell support** – the executor uses `/bin/bash` on POSIX
   systems and falls back to the default Windows shell when running on
   Windows.
+- **Desktop GUI enhancements** – the PyQt interface shows raw LLM replies in a
+  separate pane and keeps a selectable history of generated scripts.
 
 To start the server:
 

--- a/pyqt_app.py
+++ b/pyqt_app.py
@@ -1,6 +1,9 @@
 import sys
 import platform
-from typing import Dict
+import json
+import os
+import time
+from typing import Dict, List
 
 from PyQt5.QtWidgets import (
     QApplication,
@@ -12,7 +15,10 @@ from PyQt5.QtWidgets import (
     QPushButton,
     QComboBox,
     QMessageBox,
+    QListWidget,
+    QLabel,
 )
+from PyQt5.QtCore import Qt
 
 from planner import create_plan
 from executor import execute_plan
@@ -26,12 +32,36 @@ from chat_interface import (
     execute_script,
 )
 
+SCRIPT_FILE = os.path.join("logs", "scripts.json")
+
+
+def load_script_history() -> List[Dict]:
+    if os.path.exists(SCRIPT_FILE):
+        try:
+            with open(SCRIPT_FILE, "r") as f:
+                return json.load(f)
+        except Exception:
+            return []
+    return []
+
+
+def save_script_history(history: List[Dict]) -> None:
+    os.makedirs(os.path.dirname(SCRIPT_FILE), exist_ok=True)
+    with open(SCRIPT_FILE, "w") as f:
+        json.dump(history, f, indent=2)
+
+
+def add_script_history(script: str, os_type: str) -> None:
+    history = load_script_history()
+    history.insert(0, {"script": script, "os": os_type, "time": time.time()})
+    save_script_history(history)
+
 
 class ChatWindow(QWidget):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Echo")
-        self.resize(600, 400)
+        self.resize(800, 600)
 
         self.mode_box = QComboBox()
         self.mode_box.addItems(["chat", "execute", "command", "script"])
@@ -48,6 +78,14 @@ class ChatWindow(QWidget):
 
         self.log = QTextEdit()
         self.log.setReadOnly(True)
+        self.llm_log = QTextEdit()
+        self.llm_log.setReadOnly(True)
+
+        self.script_list = QListWidget()
+        self.run_script_btn = QPushButton("Run Selected")
+        self.run_script_btn.clicked.connect(self.run_selected_script)
+        self.script_history: List[Dict] = load_script_history()
+        self.refresh_scripts()
 
         self.input = QLineEdit()
         self.send_btn = QPushButton("Send")
@@ -64,12 +102,46 @@ class ChatWindow(QWidget):
 
         layout = QVBoxLayout()
         layout.addLayout(top)
+        layout.addWidget(QLabel("Chat Log"))
         layout.addWidget(self.log)
+        layout.addWidget(QLabel("LLM Output"))
+        layout.addWidget(self.llm_log)
         layout.addLayout(bottom)
+        layout.addWidget(QLabel("Scripts"))
+        layout.addWidget(self.script_list)
+        layout.addWidget(self.run_script_btn)
         self.setLayout(layout)
 
     def append_log(self, text: str) -> None:
         self.log.append(text)
+
+    def append_llm_output(self, text: str) -> None:
+        self.llm_log.append(text)
+
+    def refresh_scripts(self) -> None:
+        self.script_list.clear()
+        self.script_history = load_script_history()
+        for item in self.script_history:
+            snippet = (item.get("script", "").splitlines()[0])[:60]
+            self.script_list.addItem(snippet)
+
+    def run_selected_script(self) -> None:
+        row = self.script_list.currentRow()
+        if row < 0 or row >= len(self.script_history):
+            return
+        item = self.script_history[row]
+        script = item.get("script", "")
+        os_type = item.get("os", self.os_box.currentText())
+        ok = QMessageBox.question(
+            self,
+            "Run script",
+            f"{script}\n\nExecute?",
+        )
+        if ok == QMessageBox.Yes:
+            result = execute_script(script, os_type)
+            self.append_log(str(result))
+            add_script_history(script, os_type)
+            self.refresh_scripts()
 
     def handle_send(self):
         text = self.input.text().strip()
@@ -90,11 +162,13 @@ class ChatWindow(QWidget):
                     reply = call_openai(messages)
                 else:
                     reply = call_lmstudio(messages)
+                self.append_llm_output(reply)
                 self.append_log(f"Bot: {reply}")
 
             elif mode == "command":
                 cmd = call_anythingllm(text)
                 summary = cmd.get("summary", "")
+                self.append_llm_output(summary)
                 ok = QMessageBox.question(self, "Run command", summary)
                 if ok == QMessageBox.Yes:
                     result = execute_parsed_command(cmd)
@@ -102,6 +176,7 @@ class ChatWindow(QWidget):
 
             elif mode == "script":
                 script = create_script(text, os_type, target)
+                self.append_llm_output(script)
                 ok = QMessageBox.question(
                     self,
                     "Run script",
@@ -110,9 +185,12 @@ class ChatWindow(QWidget):
                 if ok == QMessageBox.Yes:
                     result = execute_script(script, os_type)
                     self.append_log(str(result))
+                    add_script_history(script, os_type)
+                    self.refresh_scripts()
 
             else:  # execute plan
                 plan = create_plan(text)
+                self.append_llm_output(str(plan))
                 ok = QMessageBox.question(
                     self,
                     "Execute plan",


### PR DESCRIPTION
## Summary
- improve PyQt application with a dedicated LLM output pane
- keep a selectable history of scripts in `logs/scripts.json`
- allow re-running scripts from history
- document the new GUI features in README

## Testing
- `python -m py_compile pyqt_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6887e78c6860832588bc4de0820199b6