### PR TITLE
Add network settings dialog to PyQt app

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ complex workflows can be triggered via N8N.
   Windows.
 - **Desktop GUI enhancements** – the PyQt interface shows raw LLM replies in a
   separate pane and keeps a selectable history of generated scripts.
+- **Configurable network settings** – the standalone PyQt app now includes a
+  drop-down menu to update server URLs and tokens at runtime.
 
 To start the server:
 


### PR DESCRIPTION
## Summary
- enhance README with new PyQt GUI feature
- add a settings menu in the PyQt app
- implement `SettingsDialog` for editing server URLs and tokens

## Testing
- `python -m py_compile pyqt_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6888e64c726c832589b3f2290d5da904