### PR TITLE
Add incoming LLM listener and GUI option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 port: 5000
+incoming_port: 6001
 allowlist:
   - echo
   - ls

--- a/incoming_listener.py
+++ b/incoming_listener.py
@@ -1,0 +1,38 @@
+import queue
+import threading
+from flask import Flask, request, jsonify
+
+INCOMING_QUEUE: queue.Queue[str] = queue.Queue()
+
+
+def _create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.route('/message', methods=['POST'])
+    def _message() -> 'Response':
+        data = request.get_json() or {}
+        text = data.get('message', '')
+        if not text:
+            return jsonify({'error': 'No message'}), 400
+        INCOMING_QUEUE.put(text)
+        return jsonify({'status': 'received'})
+
+    return app
+
+
+def start_listener(port: int) -> threading.Thread:
+    """Start a simple HTTP listener on the given port."""
+    app = _create_app()
+    thread = threading.Thread(
+        target=lambda: app.run(host='0.0.0.0', port=port), daemon=True
+    )
+    thread.start()
+    return thread
+
+
+def get_message(timeout: float | None = 0):
+    try:
+        return INCOMING_QUEUE.get(timeout=timeout)
+    except queue.Empty:
+        return None
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,6 +34,9 @@
         <input id="openai_url" placeholder="OpenAI URL">
         <input id="openai_token" placeholder="Token">
     </div>
+    <div class="config-item">
+        <input id="incoming_port" placeholder="Incoming Port">
+    </div>
     <button onclick="saveSettings()">Save</button>
 </div>
 <div id="toast" class="toast" style="display:none"></div>
@@ -102,6 +105,7 @@ async function loadSettings(){
         document.getElementById(svc + '_url').value = settingsData[svc + '_url'] || '';
         document.getElementById(svc + '_token').value = settingsData[svc + '_token'] || '';
     });
+    document.getElementById('incoming_port').value = settingsData.incoming_port || '';
 }
 
 async function saveSettings(){
@@ -109,6 +113,7 @@ async function saveSettings(){
         settingsData[svc + '_url'] = document.getElementById(svc + '_url').value.trim();
         settingsData[svc + '_token'] = document.getElementById(svc + '_token').value.trim();
     });
+    settingsData.incoming_port = parseInt(document.getElementById('incoming_port').value) || settingsData.incoming_port;
     await fetch('/settings', {
         method:'POST',
         headers:{'Content-Type':'application/json'},


### PR DESCRIPTION
## Summary
- configure a new `incoming_port` in `config.yaml`
- implement `incoming_listener.py` to expose a port for LLM messages
- start the listener from `chat_interface` and the PyQt app
- let the settings menu edit the incoming port
- add a source selector in the PyQt GUI and poll for incoming messages
- expose incoming port setting in web UI

## Testing
- `python -m py_compile chat_interface.py pyqt_app.py incoming_listener.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68890a3a0f048325960698fc45d037f3